### PR TITLE
[Quality + Ops] add cli for project and fix crate name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+# misc
+~

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "IoTHub"
+name = "iot_hub"
 version = "0.1.0"
 edition = "2021"
 

--- a/x.py
+++ b/x.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import fire
+import os
+from typing import TypeAlias
+
+PathType: TypeAlias = str
+ROOT_RUST_CMD = "cargo"
+
+
+def __run_cmds(args: list[str]) -> None:
+    os.system(' '.join(args))
+
+
+def run() -> None:
+    args = [ROOT_RUST_CMD, "run"]
+    __run_cmds(args)
+
+
+if __name__ == '__main__':
+    fire.Fire()


### PR DESCRIPTION
## `x.py` addition
Base CLI to hold all complex (or simple) run/build/deploy/test cmds for the project

## crate name change
![image](https://user-images.githubusercontent.com/10377570/233860183-228ee354-51e3-498d-a800-c116a48e1bc7.png)
