### PR TITLE
Parser + Command Initial Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Cargo.lock
 
 # misc
 ~
+.DS_Store
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+pest = "2.0"
+pest_derive = "2.0"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Command {
+    pub speaker : String,
+    pub action : Action,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Action {
+    Create,
+    Assign,
+    Says,
+    Speaksfor,
+    Subprincipal,
+}
+
+impl Command {
+    pub fn new(speaker: String, action: Action) -> Command {
+        Command {
+            speaker,
+            action,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+mod parser;
+mod command;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,2 @@
+
+pub mod models;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,2 +1,1 @@
-
 pub mod models;

--- a/src/parser/models/dsl.pest
+++ b/src/parser/models/dsl.pest
@@ -1,0 +1,19 @@
+WHITESPACE = _{ " " }
+type = { "bool" | "float" }
+number = @{ (ASCII_DIGIT+) ~ ("." ~ ASCII_DIGIT+)? }
+bool = { "true" | "false" }
+value = { number | bool }
+identifier = @{ (ASCII_ALPHA | ASCII_DIGIT | "_")+ }
+prim_expr = { identifier | value }
+bool_expr = { ("(" ~ ("and" | "or" | "==" | ">" | "<") ~ expr ~ expr ~ ")") | bool }
+arith_expr = { "(" ~ ("+" | "-" | "*" | "/") ~ expr ~ expr ~ ")" }
+expr = { (arith_expr | bool_expr | prim_expr) }
+speaker = { identifier }
+principal = { identifier }
+says = { "says" ~ bool_expr+ }
+create = { "create" ~ identifier ~ type ~ bool_expr}
+assign = { "assign" ~ identifier ~ value }
+speaksfor = { "speaksfor" ~ principal ~ principal ~ identifier }
+subprincipal = { "subprincipal" ~ principal ~ principal }
+stmt = { speaker ~ (says | create | assign | speaksfor | subprincipal) }
+main = { SOI ~ (stmt ~ NEWLINE)+ ~  EOI }

--- a/src/parser/models/mod.rs
+++ b/src/parser/models/mod.rs
@@ -1,0 +1,2 @@
+#![allow(dead_code)]
+pub mod parser;

--- a/src/parser/models/parser.rs
+++ b/src/parser/models/parser.rs
@@ -1,0 +1,96 @@
+use pest::Parser;
+use pest_derive::Parser;
+use crate::command::Command;
+use crate::command::Action;
+
+#[derive(Parser)]
+#[grammar = "parser/models/dsl.pest"]
+pub struct NymHubDSL;
+
+impl NymHubDSL {
+    pub fn parse_msg(msg: &String) -> Result<Vec<Command>, pest::error::Error<Rule>> {
+        let pairs = NymHubDSL::parse(Rule::main, msg)?;
+        let mut commands: Vec<Command> = Vec::new();
+        for pair in pairs.into_iter() {
+            match pair.as_rule() {
+                Rule::main => {
+                    for stmt in pair.into_inner() {
+                        match stmt.as_rule() {
+                            Rule::stmt => {
+                                let mut speaker = "";
+                                for action in stmt.into_inner() {
+                                    match action.as_rule() {
+                                        Rule::speaker => {
+                                            speaker = action.into_inner().next().unwrap().as_span().as_str();
+                                        },
+                                        Rule::says => {
+                                            commands.push(Command::new(speaker.to_string(), Action::Says));
+                                        },
+                                        Rule::assign => {
+                                            commands.push(Command::new(speaker.to_string(), Action::Assign));
+                                        },
+                                        Rule::create => {
+                                            commands.push(Command::new(speaker.to_string(), Action::Create));
+                                        },
+                                        Rule::speaksfor => {
+                                            commands.push(Command::new(speaker.to_string(), Action::Speaksfor));
+                                        },
+                                        Rule::subprincipal => {
+                                            commands.push(Command::new(speaker.to_string(), Action::Subprincipal));
+                                        },
+                                        _ => unreachable!()
+                                    }
+                                }
+                            },
+                            _  => ()
+                        };
+                    }
+                },
+                _ => unreachable!()
+            };
+        }
+        Ok(commands)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pest::Parser;
+
+    #[test]
+    fn test_parse_create() {
+        const MSG: &str = "user1 create ac_on bool true\n";
+        let _pairs = NymHubDSL::parse(Rule::main, MSG)
+            .unwrap_or_else(|e| panic!("{}", e));
+    }
+
+    #[test]
+    fn test_parse_says() {
+        const MSG: &str = "user1 says ( or ( < temp 70 ) ac_on )\n";
+        let _pairs = NymHubDSL::parse(Rule::main, MSG)
+            .unwrap_or_else(|e| panic!("{}", e));
+    }
+
+    #[test]
+    fn test_parse_assign() {
+        const MSG: &str = "thermostat assign temp 72\n";
+        let _pairs = NymHubDSL::parse(Rule::main, MSG)
+            .unwrap_or_else(|e| panic!("{}", e));
+    }
+
+    #[test]
+    fn test_gibberish_fails() {
+        const MSG: &str = "asdifuashdfalakjsdhflkh\n";
+        assert!(NymHubDSL::parse(Rule::main, MSG).is_err());
+    }
+
+    #[test]
+    fn test_parse_msg_create() {
+        const MSG: &str = "user1 create ac_on bool true\n";
+        let commands = NymHubDSL::parse_msg(&MSG.to_string()).unwrap();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].speaker, "user1");
+        assert_eq!(commands[0].action, Action::Create);
+    }
+}


### PR DESCRIPTION
Parser exports `struct NymHubDSL` with the following API:
`pub fn parse_msg(msg: &String) -> Result<Vec<Command>, pest::error::Error<Rule>>`
* Turns `msg` containing DSL string into a vector of `Command`s
* Raises error if parse failed, might panic (TODO: Fix panic later)

Command defines a (speaker, action) pair. 